### PR TITLE
fix: properly sets Backdrop initial state

### DIFF
--- a/src/Backdrop/Backdrop.js
+++ b/src/Backdrop/Backdrop.js
@@ -12,9 +12,9 @@ import Subheader from './Subheader';
 
 const Backdrop = ({ children, focused, onFocus, title, icon }) => {
   const [contentVisibility, setContentVisibility] = useState({
-    alignItems: 'stretch',
-    displayChildren: true,
-    concealed: false,
+    alignItems: focused ? 'stretch' : 'flex-end',
+    displayChildren: focused,
+    concealed: !focused,
   });
 
   useEffect(() => {


### PR DESCRIPTION
It was not possible to render the Backdrop unfocused due to its initial state