### PR TITLE
fix: wrap state update with runAfterInteractions to fix memory leak

### DIFF
--- a/src/Backdrop/Backdrop.js
+++ b/src/Backdrop/Backdrop.js
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   UIManager,
   View,
+  InteractionManager,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import useUpdateEffect from 'react-use/lib/useUpdateEffect';
@@ -27,21 +28,27 @@ const Backdrop = ({ children, focused, onFocus, title, icon }) => {
   }, []);
 
   useUpdateEffect(() => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    InteractionManager.runAfterInteractions(() => {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
 
-    if (focused) {
-      setContentVisibility({
-        alignItems: 'stretch',
-        displayChildren: true,
-        concealed: false,
-      });
-    } else {
-      setContentVisibility({
-        alignItems: 'flex-end',
-        displayChildren: false,
-        concealed: true,
-      });
-    }
+      if (focused) {
+        setContentVisibility({
+          alignItems: 'stretch',
+          displayChildren: true,
+          concealed: false,
+        });
+      } else {
+        InteractionManager.runAfterInteractions(() => {
+          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+
+          setContentVisibility({
+            alignItems: 'flex-end',
+            displayChildren: false,
+            concealed: true,
+          });
+        });
+      }
+    });
   }, [focused]);
 
   return (

--- a/src/Backdrop/__tests__/Backdrop.test.js
+++ b/src/Backdrop/__tests__/Backdrop.test.js
@@ -27,6 +27,8 @@ describe('Backdrop', () => {
     return { element, wrapper };
   };
 
+  beforeAll(() => jest.useFakeTimers());
+
   describe('When updating from focused to unfocused', () => {
     it('does not renders its children anymore', () => {
       const {
@@ -36,6 +38,7 @@ describe('Backdrop', () => {
 
       const { element: updatedElement } = setup({ focused: false });
       update(updatedElement);
+      jest.runAllTimers();
 
       expect(() => getByTestId('children')).toThrow();
     });
@@ -50,6 +53,7 @@ describe('Backdrop', () => {
 
       const { element: updatedElement } = setup({ focused: true });
       update(updatedElement);
+      jest.runAllTimers();
 
       expect(getByTestId('children')).toBeDefined();
     });


### PR DESCRIPTION
Use runAfterInteractions in order to properly wait for expensive components e.g. FlatList unmounts and then updates the state.