### PR TITLE
feat: add flex style to children

### DIFF
--- a/src/Backdrop/Backdrop.js
+++ b/src/Backdrop/Backdrop.js
@@ -107,6 +107,7 @@ const styles = StyleSheet.create({
   children: {
     marginHorizontal: 16,
     paddingVertical: 12,
+    flex: 1,
   },
 });
 


### PR DESCRIPTION
# Motivation
If I need use the entire space of backdrop, it's not possible because the children assumes the height of content. So, I just added a `flex: 1` property to the children styles.

<p align="center">Before / After</p>

<img align="left" width="300" src="https://user-images.githubusercontent.com/19699724/85794966-e0ab4500-b70d-11ea-87b5-f6d9b51d949e.png" />
<img align="right" width="300" src="https://user-images.githubusercontent.com/19699724/85794967-e143db80-b70d-11ea-8629-1b3728422c2e.png" />
