### PR TITLE
fix: TalkBack/VoiceOver focusing on elements below backdrop

### DIFF
--- a/src/Backdrop/Backdrop.js
+++ b/src/Backdrop/Backdrop.js
@@ -41,7 +41,7 @@ const Backdrop = ({
   }, [focused, preset]);
 
   return (
-    <View pointerEvents="box-none" style={styles.overlay}>
+    <View focusable={focused} pointerEvents="box-none" style={styles.overlay}>
       <View
         style={[styles.backdrop, { flex }, backdropStyle]}
         testID="backdrop"


### PR DESCRIPTION
![Screenshot from 2021-05-14 22-43-44](https://user-images.githubusercontent.com/6487206/118344676-de103480-b505-11eb-90db-e0972266f6d6.png)
