### PR TITLE
feat: add TitleComponent to  custon title

### DIFF
--- a/src/Backdrop/Backdrop.js
+++ b/src/Backdrop/Backdrop.js
@@ -18,6 +18,7 @@ const Backdrop = ({
   preset,
   titleStyle,
   backdropStyle,
+  TitleComponent,
 }) => {
   const [flex, setFlex] = useState(focused ? 1 : 0);
 
@@ -53,6 +54,7 @@ const Backdrop = ({
           title={title}
           titleStyle={titleStyle}
           testID="subheader"
+          TitleComponent={TitleComponent}
         />
         <View
           style={{

--- a/src/Backdrop/Subheader.js
+++ b/src/Backdrop/Subheader.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import Touchable from 'react-native-platform-touchable';
 import PropTypes from 'prop-types';
 
-const Subheader = ({ disabled, onPress, icon, title, titleStyle }) => {
+const Subheader = ({ disabled, onPress, icon, title, titleStyle, TitleComponent }) => {
   return (
     <Touchable
       disabled={disabled}
@@ -14,7 +14,10 @@ const Subheader = ({ disabled, onPress, icon, title, titleStyle }) => {
       accessibilityRole="button"
     >
       <View style={styles.headerContainer}>
-        <Text style={[styles.title, titleStyle]}>{title}</Text>
+        {TitleComponent ? 
+          (<TitleComponent />) : 
+          (<Text style={[styles.title, titleStyle]}>{title}</Text>)
+        }
         {icon && (
           <Touchable
             onPress={onPress}


### PR DESCRIPTION
I like much this lib, but I need add custon title component withoult remove acessibility of title.

### Example

```js

 <Backdrop
        focused={focusedBackdrop}
        onFocus={() => setFocusedBackdrop(!focusedBackdrop)}
        title="All Products"
        TitleComponent={() => (
          <View style={styles.custonContainer}>
             <MaterialIcons name="buy" size={24} color="#000" />
             <Text style={styles.custonTitle}>All Products</Text>
          </View>
        )}
        icon={
          focusedBackdrop ? (
            <MaterialIcons name="keyboard-arrow-down" size={24} color="#000" />
          ) : (
            <MaterialIcons name="keyboard-arrow-up" size={24} color="#000" />
          )
        }
        backdropStyle={styles.backdropStyle}
      >
...
```
